### PR TITLE
Fix Radiko auth endpoint

### DIFF
--- a/internal/radiko/client.go
+++ b/internal/radiko/client.go
@@ -56,7 +56,8 @@ func (c *Client) Auth() error {
 	c.logger.Debug("radiko認証を開始")
 	
 	// Step 1: auth1 - 認証トークンを取得
-	auth1URL := "https://radiko.jp/v2/api/auth1_fms"
+	// NOTE: Flash向けのauth1_fmsは廃止されたため、最新のauth1エンドポイントを使用する
+	auth1URL := "https://radiko.jp/v2/api/auth1"
 	req, err := http.NewRequest("POST", auth1URL, strings.NewReader(""))
 	if err != nil {
 		return fmt.Errorf("auth1リクエスト作成エラー: %w", err)


### PR DESCRIPTION
## Summary
- update `auth1` URL in client to avoid HTTP 404

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684525214ac88331916ac4e12c7f3509