### PR TITLE
Enable AWS Lambda deployment with SAM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM golang:1.22 AS builder
+WORKDIR /src
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main lambda/handler.go
+
+# Runtime stage
+FROM public.ecr.aws/lambda/go:1
+COPY --from=builder /src/main ${LAMBDA_TASK_ROOT}/bootstrap
+CMD ["bootstrap"]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ go build -o go-radio main.go
 ./go-radio -station=TBS -start="2024-06-07 20:00" -duration=60
 ```
 
+## AWS Lambda デプロイ (SAM + Docker)
+
+このリポジトリには `Dockerfile` と `template.yaml` が含まれており、SAM CLI を用いたコンテナベースの Lambda デプロイが可能です。
+
+1. SAM CLI をインストールします。
+2. `sam build` を実行してイメージをビルドします。
+3. `sam deploy --guided` を実行し、デプロイ情報を入力します。
+
+イベントの例:
+```json
+{
+  "station": "TBS",
+  "start": "2024-06-07 20:00",
+  "duration": 60,
+  "output": "program.aac"
+}
+```
+
+
 ## トラブルシューティング
 
 ### ffmpegが見つからない場合

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go-radio
 
 go 1.24.2
+
+require github.com/aws/aws-lambda-go v1.66.0

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+    "time"
+
+    "go-radio/internal/radiko"
+    "github.com/aws/aws-lambda-go/lambda"
+)
+
+// Event defines input parameters for the Lambda function
+type Event struct {
+    Station  string `json:"station"`
+    Start    string `json:"start"`
+    Duration int    `json:"duration"`
+    Output   string `json:"output"`
+    Verbose  bool   `json:"verbose"`
+}
+
+// Handler is the Lambda entry point
+func Handler(ctx context.Context, e Event) (string, error) {
+    logger := radiko.NewLogger(e.Verbose)
+
+    config, err := radiko.LoadConfig("")
+    if err != nil {
+        logger.Error("設定読み込み警告: %v", err)
+        config = radiko.DefaultConfig()
+    }
+
+    if e.Station == "" || e.Start == "" {
+        return "", fmt.Errorf("station and start are required")
+    }
+
+    stationID := e.Station
+    if alias, ok := config.StationAliases[strings.ToLower(stationID)]; ok {
+        stationID = alias
+    }
+
+    duration := e.Duration
+    if duration == 0 {
+        duration = config.DefaultDuration
+    }
+
+    startTime, err := time.Parse("2006-01-02 15:04", e.Start)
+    if err != nil {
+        return "", fmt.Errorf("時間の形式が正しくありません: %w", err)
+    }
+
+    if err := radiko.ValidateDateTime(startTime); err != nil {
+        return "", err
+    }
+
+    outputFile := e.Output
+    if outputFile == "" {
+        outputFile = fmt.Sprintf("%s_%s.aac", stationID, startTime.Format("20060102_1504"))
+        if config.DefaultOutputDir != "" {
+            outputFile = filepath.Join(config.DefaultOutputDir, outputFile)
+        }
+    }
+    if !strings.HasSuffix(outputFile, ".aac") {
+        outputFile += ".aac"
+    }
+
+    outputDir := filepath.Dir(outputFile)
+    if outputDir != "." {
+        if err := os.MkdirAll(outputDir, 0755); err != nil {
+            return "", fmt.Errorf("出力ディレクトリの作成に失敗: %w", err)
+        }
+    }
+
+    client := radiko.NewClient()
+    client.SetLogger(logger)
+    if err := client.Auth(); err != nil {
+        return "", fmt.Errorf("クライアント初期化に失敗: %w", err)
+    }
+
+    if err := client.RecordTimeFree(stationID, startTime, duration, outputFile); err != nil {
+        return "", fmt.Errorf("録音に失敗: %w", err)
+    }
+
+    return fmt.Sprintf("録音完了: %s", outputFile), nil
+}
+
+func main() {
+    lambda.Start(Handler)
+}
+

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Go Radio Lambda
+
+Resources:
+  RadioFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      Timeout: 900
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: .
+      DockerTag: go-radio:latest


### PR DESCRIPTION
## Summary
- add Lambda handler for recording via API event
- build Lambda container image with Docker
- define SAM template for deployment
- document SAM-based Lambda deployment in README

## Testing
- `go vet ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_6845549cda508331be366d04742aaaa6