### PR TITLE
Fix DockerTag to avoid invalid reference

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -11,4 +11,8 @@ Resources:
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .
-      DockerTag: go-radio:latest
+      # The DockerTag should be a single tag string. Using a value with a
+      # colon results in an invalid Docker reference when SAM prepends the
+      # function name. To keep the tag descriptive while valid, use a hyphen
+      # instead of a colon.
+      DockerTag: go-radio-latest


### PR DESCRIPTION
## Summary
- fix invalid DockerTag in `template.yaml`

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `sam build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455953234c8331ac3672eebc7afaec