### PR TITLE
Fix ffmpeg path for Lambda runtime

### DIFF
--- a/.aws-sam/build/template.yaml
+++ b/.aws-sam/build/template.yaml
@@ -12,7 +12,7 @@ Resources:
           VERBOSE: 'false'
           DEFAULT_DURATION: '60'
           DEFAULT_OUTPUT_DIR: /tmp/radiko
-          FFMPEG_PATH: /usr/bin/ffmpeg
+          FFMPEG_PATH: /usr/local/bin/ffmpeg
       ImageUri: radiofunction:go-radio-latest
     Metadata:
       DockerContext: /home/yamadatt/git/go-radio

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
 
 # Goアプリケーションをコピー
 COPY --from=builder /src/main ${LAMBDA_TASK_ROOT}/bootstrap
+RUN chmod +x ${LAMBDA_TASK_ROOT}/bootstrap
 
 # ffmpegのパスを環境変数に設定
 ENV PATH="/usr/local/bin:${PATH}"

--- a/template.yaml
+++ b/template.yaml
@@ -13,7 +13,7 @@ Resources:
           VERBOSE: "false"
           DEFAULT_DURATION: "60"
           DEFAULT_OUTPUT_DIR: "/tmp/radiko"
-          FFMPEG_PATH: "/usr/bin/ffmpeg"
+          FFMPEG_PATH: "/usr/local/bin/ffmpeg"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .


### PR DESCRIPTION
## Summary
- ensure bootstrap is executable in Dockerfile
- point FFMPEG_PATH to `/usr/local/bin/ffmpeg`

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684561c3c1fc833181bd10bce9adda28