### PR TITLE
Fix lambda bootstrap path for custom runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ FROM public.ecr.aws/lambda/provided:al2023
 COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
 
 # Goアプリケーションをコピー
-COPY --from=builder /src/main ${LAMBDA_TASK_ROOT}/bootstrap
-RUN chmod +x ${LAMBDA_TASK_ROOT}/bootstrap
+COPY --from=builder /src/main /var/runtime/bootstrap
+RUN chmod +x /var/runtime/bootstrap
 
 # ffmpegのパスを環境変数に設定
 ENV PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
## Summary
- ensure the compiled Lambda binary is placed at `/var/runtime/bootstrap`

## Testing
- `go vet ./...` *(fails: downloading module github.com/aws/aws-lambda-go)*
- `go test ./...` *(fails: downloading module github.com/aws/aws-lambda-go)*

------
https://chatgpt.com/codex/tasks/task_e_68456390e0b483318c71299f2bb81f8a