### PR TITLE
Fix lambda output path for writeable dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ go build -o go-radio main.go
 }
 ```
 
+`output` に相対パスを指定した場合、Lambda 実行環境では `DEFAULT_OUTPUT_DIR`
+（デフォルト `/tmp/radiko`）が自動的に付与されます。書き込みエラーが発生する
+場合は `/tmp` 以下のディレクトリを指定してください。
+
 
 ## トラブルシューティング
 
@@ -148,6 +152,9 @@ go build -o go-radio main.go
 ### 番組が見つからない場合
 - 指定した時間に番組が放送されていたか確認してください
 - タイムフリーの利用可能期間（過去1週間）内かどうか確認してください
+- `録音に失敗: open *.aac: read-only file system` というエラーが出る場合は、
+  `/tmp` 以下に書き込むよう `output` を設定するか、`DEFAULT_OUTPUT_DIR`
+  を `/tmp` 以下に指定してください
 
 ## ライセンス
 

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -110,9 +110,9 @@ func Handler(ctx context.Context, e Event) (string, error) {
 	outputFile := e.Output
 	if outputFile == "" {
 		outputFile = fmt.Sprintf("%s_%s.aac", stationID, startTime.Format("20060102_1504"))
-		if config.DefaultOutputDir != "" {
-			outputFile = filepath.Join(config.DefaultOutputDir, outputFile)
-		}
+	}
+	if !filepath.IsAbs(outputFile) && config.DefaultOutputDir != "" {
+		outputFile = filepath.Join(config.DefaultOutputDir, outputFile)
 	}
 	if !strings.HasSuffix(outputFile, ".aac") {
 		outputFile += ".aac"


### PR DESCRIPTION
## Summary
- fix lambda handler to place output under DEFAULT_OUTPUT_DIR when path is not absolute
- document Lambda output behavior and troubleshooting tips

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845850c9a0883319b4000a99fe69028