### PR TITLE
Add schedule invocation with dynamic start

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,17 @@ Resources:
       Policies:
         - S3WritePolicy:
             BucketName: "radio-transcribe"
+      Events:
+        RadioSchedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(10 22 ? * MON-THU *)
+            ScheduleExpressionTimezone: Asia/Tokyo
+            Input:
+              station: TBS
+              start: ""
+              duration: 120
+              output: yyyymmdd_hhmm.aac
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .


### PR DESCRIPTION
## Summary
- trigger the Lambda on weekdays at 22:10 JST
- compute default start time (20:00 JST) and output file when parameters are omitted

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684589680a2c8331aa09723944df4ab0