### PR TITLE
Add unit tests for radiko package

### DIFF
--- a/internal/radiko/client_test.go
+++ b/internal/radiko/client_test.go
@@ -1,0 +1,89 @@
+package radiko
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMin(t *testing.T) {
+	if min(3, 5) != 3 {
+		t.Errorf("min failed")
+	}
+	if min(10, -1) != -1 {
+		t.Errorf("min failed")
+	}
+}
+
+func TestGeneratePartialKey(t *testing.T) {
+	c := &Client{logger: NewLogger(false)}
+	got, err := c.generatePartialKey("5", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "YmNkMTU=" // base64 of "bcd15"
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
+	}
+	if _, err := c.generatePartialKey("-1", "0"); err == nil {
+		t.Errorf("expected error for invalid length")
+	}
+}
+
+func TestFindFFmpegPathViaPATH(t *testing.T) {
+	dir := t.TempDir()
+	ff := filepath.Join(dir, "ffmpeg")
+	if err := os.WriteFile(ff, []byte(""), 0755); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir)
+	c := &Client{logger: NewLogger(false)}
+	path, err := c.findFFmpegPath()
+	t.Setenv("PATH", oldPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != ff {
+		t.Errorf("expected %s, got %s", ff, path)
+	}
+}
+
+func TestFetchSegments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/main.m3u8":
+			io.WriteString(w, "#EXTM3U\nsub1.m3u8\nsegment1.ts\n")
+		case "/sub1.m3u8":
+			io.WriteString(w, "#EXTM3U\nsegment2.ts\nsegment3.ts\n")
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer server.Close()
+
+	c := &Client{httpClient: server.Client(), logger: NewLogger(false)}
+	segments, err := c.fetchSegments(server.URL + "/main.m3u8")
+	if err != nil {
+		t.Fatalf("fetchSegments error: %v", err)
+	}
+	expected := []string{
+		server.URL + "/segment2.ts",
+		server.URL + "/segment3.ts",
+		server.URL + "/segment1.ts",
+	}
+	if !reflect.DeepEqual(segments, expected) {
+		t.Errorf("segments mismatch:\nexpected=%v\n got=%v", expected, segments)
+	}
+}
+
+func TestGetAvailableStations(t *testing.T) {
+	stations := GetAvailableStations()
+	if stations["TBS"] == "" {
+		t.Errorf("expected TBS station")
+	}
+}

--- a/internal/radiko/config_test.go
+++ b/internal/radiko/config_test.go
@@ -1,0 +1,62 @@
+package radiko
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.DefaultDuration != 60 {
+		t.Errorf("expected default duration 60, got %d", cfg.DefaultDuration)
+	}
+	home, _ := os.UserHomeDir()
+	expectedDir := filepath.Join(home, "Downloads", "radiko")
+	if cfg.DefaultOutputDir != expectedDir {
+		t.Errorf("expected output dir %s, got %s", expectedDir, cfg.DefaultOutputDir)
+	}
+	if cfg.FFmpegPath != "ffmpeg" {
+		t.Errorf("expected ffmpeg path ffmpeg, got %s", cfg.FFmpegPath)
+	}
+	if len(cfg.StationAliases) == 0 {
+		t.Errorf("station aliases should not be empty")
+	}
+}
+
+func TestLoadAndSaveConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	cfg := &Config{
+		DefaultOutputDir: "/tmp/output",
+		DefaultDuration:  30,
+		StationAliases:   map[string]string{"x": "y"},
+		FFmpegPath:       "/usr/bin/ffmpeg",
+	}
+	if err := cfg.SaveConfig(path); err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if loaded.DefaultOutputDir != cfg.DefaultOutputDir || loaded.DefaultDuration != cfg.DefaultDuration || loaded.FFmpegPath != cfg.FFmpegPath {
+		t.Errorf("basic fields not restored")
+	}
+	if loaded.StationAliases["x"] != "y" {
+		t.Errorf("custom alias missing in loaded config")
+	}
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.json")
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	def := DefaultConfig()
+	if cfg.DefaultDuration != def.DefaultDuration {
+		t.Errorf("expected default duration %d, got %d", def.DefaultDuration, cfg.DefaultDuration)
+	}
+}

--- a/internal/radiko/utils_test.go
+++ b/internal/radiko/utils_test.go
@@ -1,0 +1,47 @@
+package radiko
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestValidateDateTime(t *testing.T) {
+	now := time.Now()
+	if err := ValidateDateTime(now.Add(-time.Hour)); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ValidateDateTime(now.AddDate(0, 0, -8)); err == nil {
+		t.Errorf("expected error for old time")
+	}
+	if err := ValidateDateTime(now.Add(time.Hour)); err == nil {
+		t.Errorf("expected error for future time")
+	}
+}
+
+func TestCheckFFmpeg(t *testing.T) {
+	dir := t.TempDir()
+	ff := filepath.Join(dir, "ffmpeg")
+	if err := os.WriteFile(ff, []byte(""), 0755); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	if err := CheckFFmpeg(ff); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := CheckFFmpeg(filepath.Join(dir, "missing")); err == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	if got := FormatDuration(30); got != "30分" {
+		t.Errorf("unexpected result: %s", got)
+	}
+	if got := FormatDuration(60); got != "1時間" {
+		t.Errorf("unexpected result: %s", got)
+	}
+	if got := FormatDuration(135); got != "2時間15分" {
+		t.Errorf("unexpected result: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for config, utils and client helper functions

## Testing
- `go test ./...` *(fails: github.com/aws dependencies blocked)*
- `go test -v ./internal/radiko`


------
https://chatgpt.com/codex/tasks/task_e_6845899734848331bcb927054ee53f4a