### PR TITLE
Add GitHub Actions to run Go tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Go Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs `go test ./...` when pushing or creating pull requests

## Testing
- `go test ./...` *(fails: forbidden downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684590c9d83c8331a491c2e260eb90e0