### PR TITLE
Remove unused functions

### DIFF
--- a/internal/radiko/client_test.go
+++ b/internal/radiko/client_test.go
@@ -34,25 +34,6 @@ func TestGeneratePartialKey(t *testing.T) {
 	}
 }
 
-func TestFindFFmpegPathViaPATH(t *testing.T) {
-	dir := t.TempDir()
-	ff := filepath.Join(dir, "ffmpeg")
-	if err := os.WriteFile(ff, []byte(""), 0755); err != nil {
-		t.Fatalf("create file: %v", err)
-	}
-	oldPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir)
-	c := &Client{logger: NewLogger(false)}
-	path, err := c.findFFmpegPath()
-	t.Setenv("PATH", oldPath)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if path != ff {
-		t.Errorf("expected %s, got %s", ff, path)
-	}
-}
-
 func TestFetchSegments(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/radiko/utils.go
+++ b/internal/radiko/utils.go
@@ -3,7 +3,6 @@ package radiko
 import (
 	"fmt"
 	"log"
-	"os"
 	"time"
 )
 
@@ -42,27 +41,18 @@ func (l *Logger) Fatal(format string, args ...interface{}) {
 // ValidateDateTime は日時の妥当性をチェック
 func ValidateDateTime(startTime time.Time) error {
 	now := time.Now()
-	
+
 	// 過去1週間以内かチェック
 	weekAgo := now.AddDate(0, 0, -7)
 	if startTime.Before(weekAgo) {
 		return fmt.Errorf("開始時間が古すぎます。タイムフリーは過去1週間分のみ利用可能です")
 	}
-	
+
 	// 未来の時間でないかチェック
 	if startTime.After(now) {
 		return fmt.Errorf("未来の時間は指定できません")
 	}
-	
-	return nil
-}
 
-// CheckFFmpeg はffmpegの存在をチェック
-func CheckFFmpeg(ffmpegPath string) error {
-	_, err := os.Stat(ffmpegPath)
-	if err != nil {
-		return fmt.Errorf("ffmpegが見つかりません（パス: %s）。インストールしてください", ffmpegPath)
-	}
 	return nil
 }
 

--- a/internal/radiko/utils_test.go
+++ b/internal/radiko/utils_test.go
@@ -20,20 +20,6 @@ func TestValidateDateTime(t *testing.T) {
 	}
 }
 
-func TestCheckFFmpeg(t *testing.T) {
-	dir := t.TempDir()
-	ff := filepath.Join(dir, "ffmpeg")
-	if err := os.WriteFile(ff, []byte(""), 0755); err != nil {
-		t.Fatalf("create file: %v", err)
-	}
-	if err := CheckFFmpeg(ff); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if err := CheckFFmpeg(filepath.Join(dir, "missing")); err == nil {
-		t.Errorf("expected error for missing file")
-	}
-}
-
 func TestFormatDuration(t *testing.T) {
 	if got := FormatDuration(30); got != "30分" {
 		t.Errorf("unexpected result: %s", got)


### PR DESCRIPTION
## Summary
- delete `findFFmpegPath` and `downloadWithFFmpeg`
- remove `CheckFFmpeg` helper
- drop related tests and imports

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684593af06008331aae46880ab41a86f