### PR TITLE
Refactor common setup logic

### DIFF
--- a/internal/radiko/common.go
+++ b/internal/radiko/common.go
@@ -1,0 +1,65 @@
+package radiko
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LoadConfigWithEnv loads the configuration file and applies
+// overrides from environment variables. It falls back to the
+// default configuration if loading fails.
+func LoadConfigWithEnv() (*Config, error) {
+	cfg, err := LoadConfig("")
+	if err != nil {
+		cfg = DefaultConfig()
+	}
+
+	if v := os.Getenv("DEFAULT_DURATION"); v != "" {
+		if d, convErr := strconv.Atoi(v); convErr == nil {
+			cfg.DefaultDuration = d
+		}
+	}
+
+	if v := os.Getenv("DEFAULT_OUTPUT_DIR"); v != "" {
+		cfg.DefaultOutputDir = v
+	}
+
+	if v := os.Getenv("FFMPEG_PATH"); v != "" {
+		cfg.FFmpegPath = v
+	}
+
+	return cfg, err
+}
+
+// BuildOutputPath creates the final output file path based on the
+// provided parameters and configuration. The directory part of the
+// path is created if necessary.
+func BuildOutputPath(cfg *Config, stationID, output string, start time.Time) (string, error) {
+	file := output
+	if file == "" {
+		file = fmt.Sprintf("%s_%s.aac", stationID, start.Format("20060102_1504"))
+	} else if file == "yyyymmdd_hhmm.aac" {
+		file = fmt.Sprintf("%s.aac", start.Format("20060102_1504"))
+	}
+
+	if !filepath.IsAbs(file) && cfg.DefaultOutputDir != "" {
+		file = filepath.Join(cfg.DefaultOutputDir, file)
+	}
+
+	if !strings.HasSuffix(file, ".aac") {
+		file += ".aac"
+	}
+
+	dir := filepath.Dir(file)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return "", err
+		}
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
## Summary
- add shared functions for loading config with env overrides and building output paths
- use them in CLI and Lambda handler

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68463309dffc8331a033e0ba97a9360c