### PR TITLE
Fix Lambda start time parsing

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -87,16 +87,17 @@ func Handler(ctx context.Context, e Event) (string, error) {
 	}
 
 	var startTime time.Time
+	jst, tzErr := time.LoadLocation("Asia/Tokyo")
+	if tzErr != nil {
+		jst = time.FixedZone("JST", 9*60*60)
+	}
+
 	if e.Start == "" {
-		jst, err := time.LoadLocation("Asia/Tokyo")
-		if err != nil {
-			jst = time.FixedZone("JST", 9*60*60)
-		}
 		now := time.Now().In(jst)
 		startTime = time.Date(now.Year(), now.Month(), now.Day(), 20, 0, 0, 0, jst)
 	} else {
 		var err error
-		startTime, err = time.Parse("2006-01-02 15:04", e.Start)
+		startTime, err = time.ParseInLocation("2006-01-02 15:04", e.Start, jst)
 		if err != nil {
 			return "", fmt.Errorf("時間の形式が正しくありません: %w", err)
 		}

--- a/main.go
+++ b/main.go
@@ -70,8 +70,12 @@ func main() {
 		logger.Debug("デフォルト録音時間を使用: %d分", *duration)
 	}
 
-	// 開始時間をパース
-	startDateTime, err := time.Parse("2006-01-02 15:04", *startTime)
+	// 開始時間をパース（常に日本時間として解釈）
+	jst, tzErr := time.LoadLocation("Asia/Tokyo")
+	if tzErr != nil {
+		jst = time.FixedZone("JST", 9*60*60)
+	}
+	startDateTime, err := time.ParseInLocation("2006-01-02 15:04", *startTime, jst)
 	if err != nil {
 		logger.Fatal("時間の形式が正しくありません: %v", err)
 	}


### PR DESCRIPTION
## Summary
- ensure start time is parsed in JST in Lambda handler and CLI

## Testing
- `go test ./...` *(fails: forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e0590253883319a50ace61be25c2f